### PR TITLE
Bind to all IP4 and IP6 addresses by default

### DIFF
--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -9,7 +9,7 @@ module FakeS3
     desc "server", "Run a server on a particular hostname"
     method_option :root, :type => :string, :aliases => '-r', :required => true
     method_option :port, :type => :numeric, :aliases => '-p', :required => true
-    method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to 0.0.0.0"
+    method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to all IP addresses of the machine."
     method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host.  Defaults to s3.amazonaws.com."
     method_option :quiet, :type => :boolean, :aliases => '-q', :desc => "Quiet; do not write anything to standard output."
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
@@ -45,7 +45,7 @@ module FakeS3
         end
       end
 
-      address = options[:address] || '0.0.0.0'
+      address = options[:address]
       ssl_cert_path = options[:sslcert]
       ssl_key_path = options[:sslkey]
 


### PR DESCRIPTION
This will allow us to have IP6 addresses in our /etc/hosts file which will fix our IP6 issues with resolv-replace :)

This is our forks version of https://github.com/jubos/fake-s3/pull/199. Unfortunately the master branch of our fork is all screwed up so I had to use my own fork to make the change.

@mattcross - you're prime